### PR TITLE
Always display abstract. Remove collapse behaviour.

### DIFF
--- a/templates/proceeding.html
+++ b/templates/proceeding.html
@@ -18,14 +18,14 @@
         <a href="{{proceeding.doi_link}}" target="_blank" rel="noopener">View paper (PDF)</a>
       </h3>
       {% endif %}
-      <div class="text-center p-3">
+      <!-- <div class="text-center p-3">
         <a class="card-link" data-toggle="collapse" role="button" href="#details">
           Abstract
         </a>
-      </div>
+      </div> -->
     </div>
   </div>
-  <div id="details" class="pp-card m-3 collapse">
+  <div id="details" class="pp-card m-3">
     <div class="card-body">
       <div class="card-text">
         <div id="abstractExample">


### PR DESCRIPTION
Currently, when we view the landing page for a paper (e.g. https://chilconference.org/proceeding_P094.html) we need to click "Abstract" to view the abstract:

<img width="988" alt="Screenshot 2024-07-03 at 10 10 49 AM" src="https://github.com/ahli-org/chil-website/assets/822601/31854db0-0787-4619-91eb-4969bec09e65">

The page is mostly empty, so it makes more sense to display the abstract regardless. This pull request removes the collapse behaviour, so the abstract is always displayed.

